### PR TITLE
fix(test): log normal liquidityOf rounds up if division produces rema…

### DIFF
--- a/src/DFMM.sol
+++ b/src/DFMM.sol
@@ -376,8 +376,6 @@ contract DFMM is IDFMM {
      * @dev This function should NOT be used in a non-view call, as the
      * values can be manipulated. In the future this function might be
      * removed.
-     *
-     * This function truncates the result, effectively rounding down by 1 wei.
      */
     function liquidityOf(
         address account,


### PR DESCRIPTION
…inder

The `liquidityOf` was using two divisions with truncations, leading the equals assertion to be 2 wei off. I fixed this by removing one division, and implementing the proper rounding logic by checking for remainders of the division we do. This should be reviewed by Clement to make sure our liquidityOf rounding should be doing this.