### PR TITLE
fix(DOS): cross pool dos vector removed by refunding eth only if weth…

### DIFF
--- a/src/DFMM.sol
+++ b/src/DFMM.sol
@@ -313,10 +313,13 @@ contract DFMM is IDFMM {
             if (postBalance < preBalance + downscaledAmount) {
                 revert InvalidTransfer();
             }
-        }
 
-        if (address(this).balance > 0) {
-            SafeTransferLib.safeTransferETH(msg.sender, address(this).balance);
+            // Refund any excess native ether if the token is WETH.
+            if (token == weth && address(this).balance > 0) {
+                SafeTransferLib.safeTransferETH(
+                    msg.sender, address(this).balance
+                );
+            }
         }
     }
 

--- a/src/DFMM.sol
+++ b/src/DFMM.sol
@@ -281,9 +281,13 @@ contract DFMM is IDFMM {
     // Internals
 
     /**
-     * @dev Transfers `amounts` of `tokens` from the sender to the contract. Note
-     * that if any ETH is present in the contract, it will be wrapped to WETH and
-     * used if sufficient. Any excess of ETH will be sent back to the sender.
+     * @notice Transfers `amounts` of `tokens` from the sender to the contract.
+     * @dev Note that for pools with `WETH` as a token, the contract will accept
+     * full payments in native ether. If the contract receives more ether than
+     * the amount of `WETH` needed, the contract will refund the remaining ether.
+     * If the contract receives less ether than the amount of `WETH` needed, the
+     * contract will refund the native ether and request the full amount of `WETH`
+     * needed instead.
      * @param tokens An array of token addresses to transfer.
      * @param amounts An array of amounts to transfer expressed in WAD.
      */
@@ -301,7 +305,9 @@ contract DFMM is IDFMM {
                 downscaleUp(amount, computeScalingFactor(token));
             uint256 preBalance = ERC20(token).balanceOf(address(this));
 
-            if (token == weth && address(this).balance >= amount) {
+            // note: `msg.value` can be used safely in a loop because `weth` is a unique token,
+            // therefore we only enter this branch once.
+            if (token == weth && msg.value >= amount) {
                 WETH(payable(weth)).deposit{ value: amount }();
             } else {
                 SafeTransferLib.safeTransferFrom(
@@ -309,16 +315,18 @@ contract DFMM is IDFMM {
                 );
             }
 
-            uint256 postBalance = ERC20(token).balanceOf(address(this));
-            if (postBalance < preBalance + downscaledAmount) {
-                revert InvalidTransfer();
-            }
-
-            // Refund any excess native ether if the token is WETH.
-            if (token == weth && address(this).balance > 0) {
+            // If not enough native ether was sent as payment
+            // or too much ether was sent,
+            // refund all the remaining ether back to the sender.
+            if (token == weth && msg.value != 0) {
                 SafeTransferLib.safeTransferETH(
                     msg.sender, address(this).balance
                 );
+            }
+
+            uint256 postBalance = ERC20(token).balanceOf(address(this));
+            if (postBalance < preBalance + downscaledAmount) {
+                revert InvalidTransfer();
             }
         }
     }

--- a/test/DFMM/unit/Init.t.sol
+++ b/test/DFMM/unit/Init.t.sol
@@ -17,6 +17,9 @@ contract DFMMInit is DFMMSetUp, Script {
     bytes defaultData =
         abi.encode(valid, initialInvariant, defaultReserves, initialLiquidity);
 
+    /// @notice for handling ether refunds
+    receive() external payable { }
+
     function test_DFMM_init_StoresStrategyInitialReservesAndLiquidity()
         public
     {


### PR DESCRIPTION
… token

Discussion: https://github.com/primitivefinance/DFMM/pull/89#discussion_r1550020949


For pools with `WETH`, the `_transferFrom` will try to use the native ether for the payment if `msg.value` is >= the amount required.

If `msg.value` is not zero, but also not enough to make the payment, the `else` branch will be entered which will pull the full amount of WETH tokens from the sender.

If `msg.value` is greater than the amount (leaving excess), or the `else` branch was entered, the remaining ether balance of the contract is sent to the sender. Note this is only if the token is `WETH`,