### PR TITLE
Flash swap feature

### DIFF
--- a/src/DFMM.sol
+++ b/src/DFMM.sol
@@ -268,8 +268,6 @@ contract DFMM is IDFMM {
         } else {
             // Otherwise, execute the callback and assert the input amount has been paid
             // given the before and after balances of the input token.
-            uint256 downscaledAmount =
-                downscaleUp(state.amountIn, computeScalingFactor(state.tokenIn));
             uint256 preBalance = ERC20(state.tokenIn).balanceOf(address(this));
 
             ISwapCallback(msg.sender).swapCallback(
@@ -280,6 +278,8 @@ contract DFMM is IDFMM {
                 callbackData
             );
 
+            uint256 downscaledAmount =
+                downscaleUp(state.amountIn, computeScalingFactor(state.tokenIn));
             uint256 postBalance = ERC20(state.tokenIn).balanceOf(address(this));
             if (postBalance < preBalance + downscaledAmount) {
                 revert InvalidTransfer();

--- a/src/interfaces/IDFMM.sol
+++ b/src/interfaces/IDFMM.sol
@@ -195,6 +195,7 @@ interface IDFMM {
      * @param poolId Id of the pool to swap tokens into.
      * @param recipient Address receiving the output tokens.
      * @param data An array of bytes used by the strategy contract.
+     * @param callbackData An array of bytes used in the callback function.
      * @return tokenIn Address of the token being sent.
      * @return tokenOut Address of the token being received.
      * @return amountIn Amount of token sent by the swapper.
@@ -203,7 +204,8 @@ interface IDFMM {
     function swap(
         uint256 poolId,
         address recipient,
-        bytes calldata data
+        bytes calldata data,
+        bytes calldata callbackData
     )
         external
         payable

--- a/src/interfaces/ISwapCallback.sol
+++ b/src/interfaces/ISwapCallback.sol
@@ -2,12 +2,14 @@
 pragma solidity >=0.5.0;
 
 interface ISwapCallback {
-    /// @notice              Triggered when swapping tokens in DFMM.
-    /// @param  tokenIn      Token to swap from
-    /// @param  tokenOut     Token to swap to
-    /// @param  amountIn     Amount of tokenIn to swap
-    /// @param  amountOut    Amount of tokenOut received
-    /// @param  data         Calldata passed on swap function call
+    /**
+     * @notice Triggered when swapping tokens in DFMM.
+     * @param tokenIn Token to swap from.
+     * @param tokenOut Token to swap to.
+     * @param amountIn Amount of tokenIn to swap (in WAD units).
+     * @param amountOut Amount of tokenOut received (in WAD units).
+     * @param data Calldata passed on swap function call.
+     */
     function swapCallback(
         address tokenIn,
         address tokenOut,

--- a/src/interfaces/ISwapCallback.sol
+++ b/src/interfaces/ISwapCallback.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity >=0.5.0;
+
+interface ISwapCallback {
+    /// @notice              Triggered when swapping tokens in DFMM.
+    /// @param  tokenIn      Token to swap from
+    /// @param  tokenOut     Token to swap to
+    /// @param  amountIn     Amount of tokenIn to swap
+    /// @param  amountOut    Amount of tokenOut received
+    /// @param  data         Calldata passed on swap function call
+    function swapCallback(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOut,
+        bytes calldata data
+    ) external;
+}

--- a/test/ConstantSum/unit/Swap.t.sol
+++ b/test/ConstantSum/unit/Swap.t.sol
@@ -16,7 +16,7 @@ contract ConstantSumSwapTest is ConstantSumSetUp {
         (,, bytes memory swapData) =
             solver.simulateSwap(POOL_ID, isSwapXForY, amountIn);
         (,, uint256 inputAmount, uint256 outputAmount) =
-            dfmm.swap(POOL_ID, address(this), swapData);
+            dfmm.swap(POOL_ID, address(this), swapData, "");
 
         assertEq(tokenX.balanceOf(address(dfmm)), preDfmmBalanceX + inputAmount);
         assertEq(
@@ -39,7 +39,7 @@ contract ConstantSumSwapTest is ConstantSumSetUp {
         (,, bytes memory swapData) =
             solver.simulateSwap(POOL_ID, isSwapXForY, amountIn);
         (,, uint256 inputAmount, uint256 outputAmount) =
-            dfmm.swap(POOL_ID, address(this), swapData);
+            dfmm.swap(POOL_ID, address(this), swapData, "");
 
         assertEq(tokenX.balanceOf(address(dfmm)), preDfmmBalanceX + inputAmount);
         assertEq(
@@ -62,7 +62,7 @@ contract ConstantSumSwapTest is ConstantSumSetUp {
         (,, bytes memory swapData) =
             solver.simulateSwap(POOL_ID, isSwapXForY, amountIn);
         (,, uint256 inputAmount, uint256 outputAmount) =
-            dfmm.swap(POOL_ID, address(this), swapData);
+            dfmm.swap(POOL_ID, address(this), swapData, "");
 
         assertEq(
             tokenX.balanceOf(address(dfmm)), preDfmmBalanceX - outputAmount
@@ -85,7 +85,7 @@ contract ConstantSumSwapTest is ConstantSumSetUp {
         (,, bytes memory swapData) =
             solver.simulateSwap(POOL_ID, isSwapXForY, amountIn);
         (,, uint256 inputAmount, uint256 outputAmount) =
-            dfmm.swap(POOL_ID, address(this), swapData);
+            dfmm.swap(POOL_ID, address(this), swapData, "");
 
         assertEq(
             tokenX.balanceOf(address(dfmm)), preDfmmBalanceX - outputAmount

--- a/test/DFMM/unit/Swap.t.sol
+++ b/test/DFMM/unit/Swap.t.sol
@@ -52,7 +52,8 @@ contract DFMMSwapTest is DFMMSetUp {
         dfmm.swap(
             POOL_ID,
             address(this),
-            abi.encode(true, 0, 0, 1, 1 ether, 1 ether, 1 ether)
+            abi.encode(true, 0, 0, 1, 1 ether, 1 ether, 1 ether),
+            ""
         );
         assertEq(token.balanceOf(address(this)), preBalance + feesInToken);
     }

--- a/test/DFMM/unit/Swap.t.sol
+++ b/test/DFMM/unit/Swap.t.sol
@@ -2,11 +2,71 @@
 pragma solidity ^0.8.13;
 
 import { FixedPointMathLib } from "solmate/utils/FixedPointMathLib.sol";
-import { LPToken, Pool } from "src/DFMM.sol";
+import { LPToken, Pool, ERC20, IDFMM } from "src/DFMM.sol";
+import { ISwapCallback } from "src/interfaces/ISwapCallback.sol";
+import { computeScalingFactor, downscaleUp } from "src/lib/ScalingLib.sol";
 import { DFMMSetUp } from "./SetUp.sol";
 
-contract DFMMSwapTest is DFMMSetUp {
+contract DFMMSwapTest is DFMMSetUp, ISwapCallback {
     using FixedPointMathLib for uint256;
+
+    enum SwapCallbackType {
+        Valid,
+        Invalid
+    }
+
+    function swapCallback(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOut,
+        bytes calldata data
+    ) external {
+        SwapCallbackType swapCallbackType = abi.decode(data, (SwapCallbackType));
+
+        if (swapCallbackType == SwapCallbackType.Valid) {
+            uint256 downscaledAmountIn =
+                downscaleUp(amountIn, computeScalingFactor(tokenIn));
+            ERC20(tokenIn).transfer(msg.sender, downscaledAmountIn);
+        } else if (swapCallbackType == SwapCallbackType.Invalid) {
+            return;
+        }
+    }
+
+    function test_DFMM_swap_ForwardsSwapCallbackData() public {
+        uint256[] memory reserves = new uint256[](2);
+        reserves[0] = 10 ether;
+        reserves[1] = 10 ether;
+
+        bytes memory params =
+            abi.encode(true, int256(1 ether), reserves, uint256(10 ether));
+        (POOL_ID,,) = dfmm.init(getDefaultPoolParams(params));
+
+        dfmm.swap(
+            POOL_ID,
+            address(this),
+            abi.encode(true, 1 ether, 0, 1, 1 ether, 1 ether, 1 ether),
+            abi.encode(SwapCallbackType.Valid)
+        );
+    }
+
+    function test_DFMM_swap_RevertsIfInvalidTransfer() public {
+        uint256[] memory reserves = new uint256[](2);
+        reserves[0] = 10 ether;
+        reserves[1] = 10 ether;
+
+        bytes memory params =
+            abi.encode(true, int256(1 ether), reserves, uint256(10 ether));
+        (POOL_ID,,) = dfmm.init(getDefaultPoolParams(params));
+
+        vm.expectRevert(IDFMM.InvalidTransfer.selector);
+        dfmm.swap(
+            POOL_ID,
+            address(this),
+            abi.encode(true, 1 ether, 0, 1, 1 ether, 1 ether, 1 ether),
+            abi.encode(SwapCallbackType.Invalid)
+        );
+    }
 
     function test_DFMM_swap_IncreasesTotalLiquidity() public {
         skip();

--- a/test/G3M/unit/Swap.t.sol
+++ b/test/G3M/unit/Swap.t.sol
@@ -19,7 +19,7 @@ contract G3MSwapTest is G3MSetUp {
         (, uint256 amountOut, bytes memory payload) =
             solver.simulateSwap(POOL_ID, 0, 1, amountIn);
         (,, uint256 deltaX, uint256 deltaY) =
-            dfmm.swap(POOL_ID, address(this), payload);
+            dfmm.swap(POOL_ID, address(this), payload, "");
         assertEq(amountIn, deltaX);
         assertEq(amountOut, deltaY);
 
@@ -40,7 +40,7 @@ contract G3MSwapTest is G3MSetUp {
         (, uint256 amountOut, bytes memory payload) =
             solver.simulateSwap(POOL_ID, 1, 0, amountIn);
         (,, uint256 inputAmount, uint256 outputAmount) =
-            dfmm.swap(POOL_ID, address(this), payload);
+            dfmm.swap(POOL_ID, address(this), payload, "");
 
         assertEq(
             tokenX.balanceOf(address(dfmm)), preDfmmBalanceX - outputAmount

--- a/test/LogNormal/LogNormalTest.t.sol
+++ b/test/LogNormal/LogNormalTest.t.sol
@@ -168,7 +168,7 @@ contract LogNormalTest is Test {
         (,,, bytes memory swapData) =
             solver.simulateSwap(POOL_ID, xIn, amountIn);
 
-        dfmm.swap(POOL_ID, address(this), swapData);
+        dfmm.swap(POOL_ID, address(this), swapData, "");
     }
 
     function test_ln_swap_y_in() public basic {
@@ -177,7 +177,7 @@ contract LogNormalTest is Test {
         (,,, bytes memory swapData) =
             solver.simulateSwap(POOL_ID, xIn, amountIn);
 
-        dfmm.swap(POOL_ID, address(this), swapData);
+        dfmm.swap(POOL_ID, address(this), swapData, "");
     }
 
     // todo: write assertApproxEq

--- a/test/LogNormal/unit/Swap.t.sol
+++ b/test/LogNormal/unit/Swap.t.sol
@@ -25,7 +25,7 @@ contract LogNormalSwapTest is LogNormalSetUp {
         console.log("amountOut:", amountOut);
 
         (,, uint256 inputAmount, uint256 outputAmount) =
-            dfmm.swap(POOL_ID, address(this), payload);
+            dfmm.swap(POOL_ID, address(this), payload, "");
         assertEq(tokenX.balanceOf(address(dfmm)), preDfmmBalanceX + inputAmount);
         assertEq(
             tokenY.balanceOf(address(dfmm)), preDfmmBalanceY - outputAmount
@@ -50,7 +50,7 @@ contract LogNormalSwapTest is LogNormalSetUp {
             solver.simulateSwap(POOL_ID, swapXForY, amountIn);
         assertEq(valid, true);
         (,, uint256 inputAmount, uint256 outputAmount) =
-            dfmm.swap(POOL_ID, address(this), payload);
+            dfmm.swap(POOL_ID, address(this), payload, "");
 
         assertEq(tokenY.balanceOf(address(dfmm)), preDfmmBalanceY + inputAmount);
         assertEq(
@@ -97,7 +97,7 @@ contract LogNormalSwapTest is LogNormalSetUp {
             abi.encode(1, 0, amountIn, amountOut, deltaLiquidity);
 
         vm.expectRevert();
-        dfmm.swap(POOL_ID, address(this), payload);
+        dfmm.swap(POOL_ID, address(this), payload, "");
     }
 
     function test_LogNormal_swap_ChargesCorrectFeesYIn() public deep {
@@ -108,7 +108,7 @@ contract LogNormalSwapTest is LogNormalSetUp {
             solver.simulateSwap(POOL_ID, swapXForY, amountIn);
 
         (,, uint256 inputAmount, uint256 outputAmount) =
-            dfmm.swap(POOL_ID, address(this), payload);
+            dfmm.swap(POOL_ID, address(this), payload, "");
 
         console2.log(inputAmount);
         console2.log(outputAmount);
@@ -122,7 +122,7 @@ contract LogNormalSwapTest is LogNormalSetUp {
             solver.simulateSwap(POOL_ID, swapXForY, amountIn);
 
         (,, uint256 inputAmount, uint256 outputAmount) =
-            dfmm.swap(POOL_ID, address(this), payload);
+            dfmm.swap(POOL_ID, address(this), payload, "");
 
         console2.log(inputAmount);
         console2.log(outputAmount);

--- a/test/NTokenGeometricMean/NTokenGeometricMean.t.sol
+++ b/test/NTokenGeometricMean/NTokenGeometricMean.t.sol
@@ -269,7 +269,7 @@ contract NTokenGeometricMeanTest is Test {
             "price tIn", computePrice(tokenInIndex, preReserves, params)
         );
 
-        dfmm.swap(POOL_ID, address(this), data);
+        dfmm.swap(POOL_ID, address(this), data, "");
         (uint256[] memory postReserves,) =
             solver.getReservesAndLiquidity(POOL_ID);
         console2.log(
@@ -376,7 +376,7 @@ contract NTokenGeometricMeanTest is Test {
         (bool valid, uint256 amountOut, bytes memory data) =
             solver.simulateSwap(POOL_ID, tokenInIndex, tokenOutIndex, amountIn);
 
-        dfmm.swap(POOL_ID, address(this), data);
+        dfmm.swap(POOL_ID, address(this), data, "");
     }
 
     function test_4_token_compute_price_non_uniform()


### PR DESCRIPTION
Flash swaps will optimistically send tokens out during swaps before the input tokens are requested. This will enable the output of a swap to be used for payments in other integrated protocols.

Changes:
- Adds `callbackData` argument to `swap()`. This argument is passed to the callback() to `msg.sender`. If the length of data is `0`, it will not do the callback and instead use `_transferFrom()`.
- Adds the `ISwapCallback` interface to define the callback function.
- Re-orders the business logic of the swap token transfers to transfer the tokens to `recipient` before the input tokens are required/requested.

Concerns:
- cross pool interaction using flash swaps
- incorrect usage of callback
- arbitrary data passed through the swap entrypoint is arbitrary (but only used in the callback call)